### PR TITLE
Add rename option, lower batch sizes

### DIFF
--- a/migrator/src/main/java/com/mongodb/migratecluster/commandline/ApplicationOptions.java
+++ b/migrator/src/main/java/com/mongodb/migratecluster/commandline/ApplicationOptions.java
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mongodb.migratecluster.utils.ListUtils;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * File: ApplicationOptions
@@ -20,6 +22,7 @@ public class ApplicationOptions {
     private boolean showHelp;
     private boolean dropTarget;
     private List<ResourceFilter> blackListFilter;
+    private Map<String, String> renames;
 
     public ApplicationOptions() {
         sourceCluster = "";
@@ -29,6 +32,7 @@ public class ApplicationOptions {
         showHelp = false;
         dropTarget = false;
         setBlackListFilter(new ArrayList<>());
+        setRenames(new HashMap<>());
     }
 
 
@@ -102,6 +106,15 @@ public class ApplicationOptions {
                 this.isShowHelp(), this.getConfigFilePath(), this.getSourceCluster(),
                 this.getTargetCluster(), this.getOplogStore(), this.isDropTarget(),
                 ListUtils.select(this.getBlackListFilter(), f -> f.toString()));
+    }
+
+    @JsonProperty("renames")
+	public Map<String, String> getRenames() {
+		return renames;
+	}
+    
+    public void setRenames(Map<String, String> renames) {
+    	this.renames = renames;
     }
 
 }

--- a/migrator/src/main/java/com/mongodb/migratecluster/migrators/CollectionDataMigrator.java
+++ b/migrator/src/main/java/com/mongodb/migratecluster/migrators/CollectionDataMigrator.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -41,10 +42,12 @@ public class CollectionDataMigrator extends BaseMigrator {
     final static Logger logger = LoggerFactory.getLogger(CollectionDataMigrator.class);
     private final Object lockObject = new Object();
     private final ConcurrentHashMap<Resource, CollectionDataTracker> oplogDataTrackers;
-
+    private final Map<String, String> renameOptions;
+    
     public CollectionDataMigrator(ApplicationOptions options) {
         super(options);
         oplogDataTrackers = new ConcurrentHashMap<>();
+        renameOptions = options.getRenames();
     }
 
     /**
@@ -111,11 +114,11 @@ public class CollectionDataMigrator extends BaseMigrator {
                 resourceObservable
                     .map(resource -> {
                         logger.info("found collection {}", resource.getNamespace());
-                        dropTargetCollectionIfRequired(targetClient, resource);
+                        dropTargetCollectionIfRequired(targetClient, resource, renameOptions);
                         Document latestDocumentId = getOplogStoreLatestDocumentIdForGivenResource(oplogClient, resource);
                         return new DocumentReader(sourceClient, resource, latestDocumentId);
                     })
-                    .map(reader -> new DocumentWriter(targetClient, reader))
+                    .map(reader -> new DocumentWriter(targetClient, reader, renameOptions))
                     .subscribe(writer -> {
                         writer
                             .map((DocumentsBatch batch) -> {
@@ -197,9 +200,17 @@ public class CollectionDataMigrator extends BaseMigrator {
      * @param client a MongoDB client object to work with collections
      * @param resource a collection in a database
      */
-    private void dropTargetCollectionIfRequired(MongoClient client, Resource resource) {
+    private void dropTargetCollectionIfRequired(MongoClient client, Resource resource, Map<String, String> renames) {
         if (options.isDropTarget()) {
-            MongoDBHelper.dropCollection(client, resource.getDatabase(), resource.getCollection());
+        	String databaseName = resource.getDatabase();
+        	String collectionName = resource.getCollection();
+        	if (renames.containsKey(databaseName)) {
+        		databaseName = renames.get(databaseName);
+        	}
+        	if (renames.containsKey(collectionName)) {
+        		collectionName = renames.get(collectionName);
+        	}
+            MongoDBHelper.dropCollection(client, databaseName, collectionName);
         }
     }
 

--- a/migrator/src/main/java/com/mongodb/migratecluster/migrators/MigratorSettings.java
+++ b/migrator/src/main/java/com/mongodb/migratecluster/migrators/MigratorSettings.java
@@ -1,7 +1,7 @@
 package com.mongodb.migratecluster.migrators;
 
 public final class MigratorSettings {
-    public static final int BATCH_SIZE_ID_READER = 5000;
+    public static final int BATCH_SIZE_ID_READER = 1000; // 5000;
     public static final int BATCHES_MAX_COUNT = 2;
-    public static final int BATCH_SIZE_DOC_READER = 1000;
+    public static final int BATCH_SIZE_DOC_READER = 200; // 1000;
 }

--- a/migrator/src/main/java/com/mongodb/migratecluster/migrators/OplogMigrator.java
+++ b/migrator/src/main/java/com/mongodb/migratecluster/migrators/OplogMigrator.java
@@ -96,10 +96,10 @@ public class OplogMigrator extends BaseMigrator {
      * @return a oplog timestamp fetched from the oplog store
      */
     private BsonTimestamp getTimestampFromOplogStore() {
-        if (options.isDropTarget()) {
-            return null;
-        }
-        else {
+//        if (options.isDropTarget()) {
+//            return null;
+//        }
+//        else {
             MongoClient client = this.getOplogClient();
             ReadOnlyTracker tracker = new OplogTimestampTracker(client, oplogTrackerResource, this.migratorName);
             Document document = tracker.getLatestDocument();
@@ -108,7 +108,7 @@ public class OplogMigrator extends BaseMigrator {
                 return null;
             }
             return document.get("ts", BsonTimestamp.class);
-        }
+//        }
     }
 
     /**
@@ -158,6 +158,7 @@ public class OplogMigrator extends BaseMigrator {
         MongoClient sourceClient = getSourceClient();
         MongoClient targetClient = getTargetClient();
         MongoClient oplogStoreClient = getOplogClient();
+        logger.info("copyOplogsFromSourceToOplogstore timestamp: {}", lastTimestamp);
         OplogBufferedReader reader = new OplogBufferedReader(sourceClient, lastTimestamp);
         OplogWriter writer = new OplogWriter(targetClient, oplogStoreClient, this.migratorName, this.options);
 


### PR DESCRIPTION
As discussed, a variation of migrate-mongo-cluster that supports a rename of database or collection. Further the default batch sizes were reduced by 1/5 to stop an out of memory error from happening.

A sample config that allows for renames:

> {
> 	"sourceCluster": "localhost:28000/?replicaSet=RS",
> 	"targetCluster": "localhost:29000/?replicaSet=RS2",
> 	"oplogStore":    "localhost:30000/?replicaSet=rsOplog",
> 	"dropTarget": true,
> 	"blackListFilter" : [
> 		{ "database" : "admin",  "collection" : "{}" },
> 		{ "database" : "config", "collection" : "{}" },
> 		{ "database" : "local", "collection" : "{}" }
> 	],
> 	"renames" : {
> 		"load": "load3",
> 		"numbers": "numbers3"
> 	}
> }